### PR TITLE
Fixed bug that throws exception when there are no steps.

### DIFF
--- a/src/wizard.js
+++ b/src/wizard.js
@@ -37,10 +37,12 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                 //checking to make sure currentStep is truthy value
                 if (!step) return;
                 //setting stepTitle equal to current step title or default title
-                var stepTitle = $scope.selectedStep.title || $scope.selectedStep.wzTitle;
-                if ($scope.selectedStep && stepTitle !== $scope.currentStep) {
-                    //invoking goTo() with step title as argument
-                    $scope.goTo(_.findWhere($scope.steps, {title: $scope.currentStep}));
+                if($scope.selectedStep) {
+                    var stepTitle = $scope.selectedStep.title || $scope.selectedStep.wzTitle;
+                    if (stepTitle !== $scope.currentStep) {
+                        //invoking goTo() with step title as argument
+                        $scope.goTo(_.findWhere($scope.steps, {title: $scope.currentStep}));
+                    }
                 }
 
             });

--- a/test/angularWizardSpec.js
+++ b/test/angularWizardSpec.js
@@ -15,9 +15,9 @@ describe( 'AngularWizard', function() {
      * @param  {Scope} scope         A scope to bind to
      * @return {[DOM element]}       A DOM element compiled
      */
-    function createView(scope) {
+    function createView(scope, element) {
         scope.referenceCurrentStep = null;
-        var element = angular.element('<wizard on-finish="finishedWizard()" current-step="referenceCurrentStep" ng-init="msg = 14" >'
+        var element = element || angular.element('<wizard on-finish="finishedWizard()" current-step="referenceCurrentStep" ng-init="msg = 14" >'
                 + '    <wz-step title="Starting" canenter="enterValidation">'
                 + '        <h1>This is the first step</h1>'
                 + '        <p>Here you can use whatever you want. You can use other directives, binding, etc.</p>'
@@ -206,5 +206,14 @@ describe( 'AngularWizard', function() {
         WizardHandler.wizard().finish();
         expect(flag).toBeTruthy();
         $rootScope.$digest();
+    });
+    it( "should not throw when currentStep changes and there is no selectedStep", function() {
+        var scope = $rootScope.$new();
+        var element = angular.element('<wizard current-step="referenceCurrentStep"></wizard>');
+        var view = createView(scope, element);
+        scope.referenceCurrentStep = 'anything';
+        expect(function() {
+            $rootScope.$digest();
+        }).not.toThrow();
     });
 });


### PR DESCRIPTION
The bug also occurs on rare occasions during the first run even if steps exist but a "selectedStep" hasn't been assigned.

I also added a test demonstrating the issue. Note that the view for the new test is different from the views for the existing tests.
