### PR TITLE
Allow canenter and canexit to be strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "grunt-contrib-clean": "~0.4.1",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-copy": "~0.4.1",
-    "grunt-contrib-less": "~1.0.0",
     "grunt-contrib-cssmin": "~0.12.2",
+    "grunt-contrib-less": "~1.0.0",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-conventional-changelog": "~0.1.1",
     "grunt-html2js": "~0.1.3",
@@ -53,9 +53,11 @@
     "grunt-ng-annotate": "^0.6.0",
     "grunt-zip": "*",
     "jasmine-core": "^2.1.3",
+    "karma": "^0.12.0",
     "karma-chrome-launcher": "^0.1.7",
+    "karma-coverage": "^1.1.1",
     "karma-firefox-launcher": "~0.1.x",
-    "karma-jasmine": "~0.3.x",
+    "karma-jasmine": "^0.3.8",
     "karma-phantomjs-launcher": "~0.1.x"
   },
   "license": "MIT"

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -104,7 +104,7 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                     $scope.goTo($scope.getEnabledSteps()[0]);
                 }
             };
-            
+
             //called each time step directive is destroyed
             this.removeStep = function (step) {
                 var index = $scope.steps.indexOf(step);
@@ -177,8 +177,15 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                 if(typeof step.canenter === 'boolean'){
                     return step.canenter;
                 }
+                var canEnter;
+                //If canenter is a string instead of a function, evaluate the function
+                if(typeof step.canenter === 'string'){
+                    var splitFunction = step.canenter.split('(');
+                    canEnter = eval('$scope.$parent.' + splitFunction[0] + '($scope.context' + splitFunction[1])
+                } else {
+                    canEnter = step.canenter($scope.context);
+                }
                 //Check to see if the canenter function is a promise which needs to be returned
-                canEnter = step.canenter($scope.context);
                 if(angular.isFunction(canEnter.then)){
                     defer = $q.defer();
                     canEnter.then(function(response){
@@ -201,8 +208,15 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                 if(typeof step.canexit === 'boolean'){
                     return step.canexit;
                 }
+                var canExit;
+                //If canenter is a string instead of a function, evaluate the function
+                if(typeof step.canexit === 'string'){
+                    var splitFunction = step.canexit.split('(');
+                    canExit = eval('$scope.$parent.' + splitFunction[0] + '($scope.context' + splitFunction[1])
+                } else {
+                    canExit = step.canexit($scope.context);
+                }
                 //Check to see if the canexit function is a promise which needs to be returned
-                canExit = step.canexit($scope.context);
                 if(angular.isFunction(canExit.then)){
                     defer = $q.defer();
                     canExit.then(function(response){
@@ -318,7 +332,7 @@ angular.module('mgo-angular-wizard').directive('wizard', function() {
                     $scope.onFinish();
                 }
             };
-            
+
             this.previous = function() {
                 //getting index of current step
                 var index = stepIdx($scope.selectedStep);

--- a/test/angularWizardSpec.js
+++ b/test/angularWizardSpec.js
@@ -257,6 +257,27 @@ describe( 'AngularWizard', function() {
         $timeout.flush();
         expect(scope.referenceCurrentStep).toEqual('More steps');
     });
+    it( "should go to the next step because the promise that the evaluated string of CANENTER resolves to true", function(done) {
+        var scope = $rootScope.$new();
+        scope.dynamicStepDisabled = 'Y';
+        var view = createGenericView(scope);
+        scope.enterValidation = 'stringEnterValidation()'
+        scope.stringEnterValidation = function(){
+            var deferred = $q.defer();
+            $timeout(function () {
+                deferred.resolve(true);
+                done();
+            });
+            return deferred.promise;
+        };
+        expect(scope.referenceCurrentStep).toEqual('Starting');
+        WizardHandler.wizard().next();
+        $rootScope.$digest();
+        expect(scope.referenceCurrentStep).toEqual('Continuing');
+        WizardHandler.wizard().next();
+        $timeout.flush();
+        expect(scope.referenceCurrentStep).toEqual('More steps');
+    });
     it( "should go to the next step because CANEXIT is set to true", function() {
         var scope = $rootScope.$new();
         scope.dynamicStepDisabled = 'Y';
@@ -268,6 +289,27 @@ describe( 'AngularWizard', function() {
         expect(scope.referenceCurrentStep).toEqual('Continuing');
         WizardHandler.wizard().next();
         $rootScope.$digest();
+        expect(scope.referenceCurrentStep).toEqual('More steps');
+    });
+    it( "should go to the next step because the promise that the evaluated string of CANEXIT resolves to true", function(done) {
+        var scope = $rootScope.$new();
+        scope.dynamicStepDisabled = 'Y';
+        var view = createGenericView(scope);
+        scope.stepValidation = 'stringStepValidation()'
+        scope.stringStepValidation = function(){
+            var deferred = $q.defer();
+            $timeout(function () {
+                deferred.resolve(true);
+                done();
+            });
+            return deferred.promise;
+        };
+        expect(scope.referenceCurrentStep).toEqual('Starting');
+        WizardHandler.wizard().next();
+        $rootScope.$digest();
+        expect(scope.referenceCurrentStep).toEqual('Continuing');
+        WizardHandler.wizard().next();
+        $timeout.flush();
         expect(scope.referenceCurrentStep).toEqual('More steps');
     });
     it( "should finish", function() {


### PR DESCRIPTION
I ran into a problem when using this library in a project of mine that has multiple wizards. I refactored much of my wizard code to allow me to loop through steps defined in my controller (using ng-repeat). However, I couldn't dynamically set the "canenter" or "canexit" attributes of the "wz-step" directive. I did the following in my project and it seems to be working perfectly!

Example:

``` javascript
// In my controller
$scope.wizardSteps = {
      step1: {
        title: 'Step 1', description: 'This is Step 1',
        renderFile: 'path/to/file/step1.html'
      },
      step2: {
        title: 'Step 2', description: 'This is Step 2',
        renderFile: 'path/to/file/step2.html', enterCallback: 'doSomethingUseful()'
      }
};

$scope.doSomethingUseful = function() {
  // Do stuff and return a promise as I normally would for a canenter callback
};
```

``` slim
// View (this is Slim since I'm using a Rails app)
wizard[current-step='currentStep']
  wz-step[ng-repeat='(stepIdentifier, step) in wizardSteps' wz-title='{{ step.title }}' canenter='step.enterCallback']
    // Other code shared between all steps
    div[ng-include='step.renderFile' ng-if='step.renderFile']
```
