### PR TITLE
If two view use the same controller name, switching between the two view will result in the initialization and delete operation simultaneously.

### DIFF
--- a/src/wizardHandler.js
+++ b/src/wizardHandler.js
@@ -1,26 +1,39 @@
 angular.module('mgo-angular-wizard').factory('WizardHandler', function() {
    var service = {};
-   
+
    var wizards = {};
-   
+
+    var duplicate = {};
+
    service.defaultName = "defaultWizard";
-   
-   service.addWizard = function(name, wizard) {
-       wizards[name] = wizard;
+
+   service.addWizard = function (name, wizard) {
+       if (wizards[name]) {
+           duplicate[name] = wizards[name];
+           wizards[name] = wizard;
+           return true;
+       } else {
+           wizards[name] = wizard;return false;
+       }
    };
-   
-   service.removeWizard = function(name) {
+
+   service.removeWizard = function (name) {
+       if (duplicate[name]) {
+           delete duplicate[name];
+           return true;
+       }
        delete wizards[name];
+       return false;
    };
-   
+
    service.wizard = function(name) {
        var nameToUse = name;
        if (!name) {
            nameToUse = service.defaultName;
        }
-       
+
        return wizards[nameToUse];
    };
-   
+
    return service;
 });


### PR DESCRIPTION
If two view use the same controller name, switching between the two view will result in the initialization and delete operation simultaneously.

Now enter the controller at the same time to assign the name of the current route, you can solve the problem

version 1

in controller
`$scope.pageName=$state.current.name;`

in view
`<wizard name="{{pageName}}"`
version 2

in controller
do nothing.

in view
do nothing.