### PR TITLE
Use ng-if instead of ng-show for wzHeadingTitle.

### DIFF
--- a/src/wizard.html
+++ b/src/wizard.html
@@ -1,5 +1,5 @@
 <div>
-    <h2 ng-show="selectedStep.wzHeadingTitle != ''">{{ selectedStep.wzHeadingTitle }}</h2>
+    <h2 ng-if="selectedStep.wzHeadingTitle != ''">{{ selectedStep.wzHeadingTitle }}</h2>
 
     <div class="steps" ng-if="indicatorsPosition === 'bottom'" ng-transclude></div>
     <ul class="steps-indicator steps-{{getEnabledSteps().length}}" ng-if="!hideIndicators">


### PR DESCRIPTION
`h2` normally has margins, which are still preserved even if hidden. This means upgrading to the latest version adds extra empty space.